### PR TITLE
Update SwiftAthmovilCheckoutFlutterPlugin.swift

### DIFF
--- a/ios/Classes/SwiftAthmovilCheckoutFlutterPlugin.swift
+++ b/ios/Classes/SwiftAthmovilCheckoutFlutterPlugin.swift
@@ -66,8 +66,9 @@
                 Self.channel?.invokeMethod(
                     ConstantsUtil.call.ATHM_PAYMENT_RESULT,arguments: jsonResponse
                 )
+                return true
             }
-            return true
+            return false
         }
         
         // On Resume Event for iOS


### PR DESCRIPTION
Fixed a bug due to which deep links did not work in the `uni_links` plugin.
When returning true all the time, all delegate subscribers do not have their `application:openURL:options` method called.